### PR TITLE
Proper handling of willSelectRowAt

### DIFF
--- a/Sources/Table/Cell Adapters/TableCellAdapter+Support.swift
+++ b/Sources/Table/Cell Adapters/TableCellAdapter+Support.swift
@@ -25,6 +25,17 @@ public enum TableAdapterCellAction {
 	case deselectAnimated
 }
 
+/// Row that will be de/selected.
+///
+/// - none: don't de/select any row.
+/// - sameRow: de/select the row where the action happened.
+/// - otherRow: de/select any arbitrary row.
+public enum TableAdapterCellRowSelection {
+	case none
+	case sameRow
+	case otherRow(at: IndexPath)
+}
+
 public extension TableCellAdapter {
 
 	// MARK: - TableAdapter.Event -
@@ -89,10 +100,10 @@ public extension TableCellAdapter {
 		public var shouldSpringLoad: ((Event) -> Bool)? = nil
 		public var tapOnAccessory: ((Event) -> Void)? = nil
 
-		public var willSelect: ((Event) -> IndexPath?)? = nil
+		public var willSelect: ((Event) -> TableAdapterCellRowSelection)? = nil
 		public var didSelect: ((Event) -> TableAdapterCellAction)? = nil
-		public var willDeselect: ((Event) -> IndexPath?)? = nil
-		public var didDeselect: ((Event) -> IndexPath?)? = nil
+		public var willDeselect: ((Event) -> TableAdapterCellRowSelection)? = nil
+		public var didDeselect: ((Event) -> Void)? = nil
 
 		public var willBeginEdit: ((Event) -> Void)? = nil
 		public var didEndEdit: ((Event) -> Void)? = nil

--- a/Sources/Table/TableDirector.swift
+++ b/Sources/Table/TableDirector.swift
@@ -646,7 +646,14 @@ extension TableDirector: UITableViewDataSource, UITableViewDelegate {
 
 	public func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
 		let (model, adapter) = context(forItemAt: indexPath)
-		return (adapter.dispatchEvent(.willSelect, model: model, cell: nil, path: indexPath, params: nil) as? IndexPath) ?? indexPath
+		guard let rowSelection = adapter.dispatchEvent(.willSelect, model: model, cell: nil, path: indexPath, params: nil) as? TableAdapterCellRowSelection else {
+			return indexPath
+		}
+		switch rowSelection {
+		case .none: return nil
+		case .sameRow: return indexPath
+		case let .otherRow(at): return at
+		}
 	}
 
 	public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -666,7 +673,14 @@ extension TableDirector: UITableViewDataSource, UITableViewDelegate {
 
 	public func tableView(_ tableView: UITableView, willDeselectRowAt indexPath: IndexPath) -> IndexPath? {
 		let (model, adapter) = context(forItemAt: indexPath)
-		return (adapter.dispatchEvent(.willDeselect, model: model, cell: nil, path: indexPath, params: nil) as? IndexPath)
+		guard let rowSelection = adapter.dispatchEvent(.willDeselect, model: model, cell: nil, path: indexPath, params: nil) as? TableAdapterCellRowSelection else {
+			return indexPath
+		}
+		switch rowSelection {
+		case .none: return nil
+		case .sameRow: return indexPath
+		case let .otherRow(at): return at
+		}
 	}
 
 	public func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
Currently the library is not properly handling `willSelectRowAt` since there is noway to have it return `nil` (in case you want to prevent a row from being selected). The root of the issue is the Nil-coalescing operation in this line:
```swift
return (adapter.dispatchEvent(.willSelect, model: model, cell: nil, path: indexPath, params: nil) as? IndexPath) ?? indexPath
```

I thought about just removing it, but instead decided to use an approach similar to what you did with `TableAdapterCellAction` - thoughts?

P.S.: also made `willDeselectRowAt` consistent to `willSelectRowAt`, and changed the return type of `didDeselect` to `Void` (since it's not used anyway).