### PR TITLE
Check for invalid indexPath to avoid crashes

### DIFF
--- a/Sources/Collection/CollectionDirector.swift
+++ b/Sources/Collection/CollectionDirector.swift
@@ -153,6 +153,9 @@ open class CollectionDirector: NSObject,
     ///   - indexPath: index path.
     /// - Returns: adapter if any
     internal func adapterForHeaderFooter(_ kind: String, indexPath: IndexPath) -> CollectionHeaderFooterAdapterProtocol? {
+        guard indexPath.section >= 0, indexPath.section < sections.count else {
+            return nil
+        }
         let adapter: CollectionHeaderFooterAdapterProtocol?
         switch kind {
         case UICollectionView.elementKindSectionHeader:
@@ -516,6 +519,9 @@ public extension CollectionDirector {
 	}
 
 	func headerFooterForSection(ofType type: String, at indexPath: IndexPath) -> CollectionHeaderFooterAdapterProtocol? {
+        guard indexPath.section >= 0, indexPath.section < sections.count else {
+            return nil
+        }
 		switch type {
 		case UICollectionView.elementKindSectionHeader:
 			return sections[indexPath.section].headerView


### PR DESCRIPTION
I have experienced crashes when certain collection view delegate methods (related to headers and footers) are called with indexPaths equal to `(section: NSNotFound, item: NSNotFound)`. I added range checks similar to what you already had in other delegate methods.