### PR TITLE
Added check if exists row and section on didEndEditing.

### DIFF
--- a/Sources/Owl/Table/TableDirector.swift
+++ b/Sources/Owl/Table/TableDirector.swift
@@ -678,6 +678,9 @@ extension TableDirector: UITableViewDataSource, UITableViewDelegate {
 
 	public func tableView(_ tableView: UITableView, didEndEditingRowAt indexPath: IndexPath?) {
 		guard let indexPath = indexPath else { return }
+        if indexPath.row >= tableView.numberOfRows(inSection: indexPath.section) {
+            return
+        }
         let (model, adapter) = context(forItemAt: indexPath)
         adapter.dispatchEvent(.didEndEdit, model: model, cell: nil, path: indexPath, params: nil)
     }


### PR DESCRIPTION
Before that, if you delete the last row of a TableView, it tried to get context for an IndexPath greater than the number of elements in your sections, causing an Index out of range.