### PR TITLE
Fixed inappropriate TableView reload and added correct events in CollectionDirector

### DIFF
--- a/OwlKit.podspec
+++ b/OwlKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "OwlKit"
-  s.version      = "1.1.3"
+  s.version      = "1.2.0"
   s.summary      = "A declarative type-safe framework for building fast and flexible list with Tables & Collections"
   s.description  = <<-DESC
     Owl offers a data-driven declarative approach for building fast & flexible list in iOS. It supports both UICollectionView & UITableView; UIStackView is on the way!.

--- a/Sources/Owl/Collection/Cell Adapter/CollectionCellAdapter+Events.swift
+++ b/Sources/Owl/Collection/Cell Adapter/CollectionCellAdapter+Events.swift
@@ -78,6 +78,9 @@ public extension CollectionCellAdapter {
 		public var prefetch: ((_ items: [Model], _ paths: [IndexPath]) -> Void)? = nil
 		public var cancelPrefetch: ((_ items: [Model], _ paths: [IndexPath]) -> Void)? = nil
 		public var shouldSpringLoad: ((Event) -> Bool)? = nil
+    
+    @available(iOS 13, *)
+    public lazy var contextMenuConfiguration: ((Event) -> UIContextMenuConfiguration?)? = nil
 	}
 
 }
@@ -103,4 +106,5 @@ public enum CollectionAdapterEventID: Int {
 	case prefetch
 	case cancelPrefetch
 	case shouldSpringLoad
+  case contextMenuConfiguration
 }

--- a/Sources/Owl/Collection/Cell Adapter/CollectionCellAdapter.swift
+++ b/Sources/Owl/Collection/Cell Adapter/CollectionCellAdapter.swift
@@ -132,6 +132,10 @@ open class CollectionCellAdapter<Model: ElementRepresentable, Cell: ReusableView
 		case .shouldSpringLoad:
 			return events.shouldSpringLoad?(CollectionCellAdapter.Event(element: model, cell: cell, path: path))
 			
+    case .contextMenuConfiguration:
+      if #available(iOS 13, *) {
+        return events.contextMenuConfiguration?(CollectionCellAdapter.Event(element: model, cell: cell, path: path))
+      }
 		}
 
 		return nil

--- a/Sources/Owl/Collection/CollectionDirector.swift
+++ b/Sources/Owl/Collection/CollectionDirector.swift
@@ -477,6 +477,12 @@ public extension CollectionDirector {
 		let (model, adapter) = context(forItemAt: indexPath)
 		return (adapter.dispatchEvent(.shouldShowEditMenu, model: model, cell: nil, path: indexPath, params: nil) as? Bool) ?? false
 	}
+  
+  @available(iOS 13.0, *)
+  func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+    let (model, adapter) = context(forItemAt: indexPath)
+    return adapter.dispatchEvent(.contextMenuConfiguration, model: model, cell: nil, path: indexPath, params: nil) as? UIContextMenuConfiguration
+  }
 
 	// MARK: - Actions -
 

--- a/Sources/Owl/Collection/CollectionDirector.swift
+++ b/Sources/Owl/Collection/CollectionDirector.swift
@@ -483,6 +483,11 @@ public extension CollectionDirector {
     let (model, adapter) = context(forItemAt: indexPath)
     return adapter.dispatchEvent(.contextMenuConfiguration, model: model, cell: nil, path: indexPath, params: nil) as? UIContextMenuConfiguration
   }
+  
+  @available(iOS 13.0, *)
+  func collectionView(_ collectionView: UICollectionView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    return events.contextMenuPreview?(configuration)
+  }
 
 	// MARK: - Actions -
 

--- a/Sources/Owl/Collection/CollectionDirector.swift
+++ b/Sources/Owl/Collection/CollectionDirector.swift
@@ -411,7 +411,7 @@ public extension CollectionDirector {
 
 	func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
 		let (model, adapter) = context(forItemAt: indexPath)
-		return (adapter.dispatchEvent(.didDeselect, model: model, cell: nil, path: indexPath, params: nil) as? Bool) ?? true
+		return (adapter.dispatchEvent(.shouldSelect, model: model, cell: nil, path: indexPath, params: nil) as? Bool) ?? true
 	}
 
 	func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
@@ -435,7 +435,7 @@ public extension CollectionDirector {
 
 	func collectionView(_ collectionView: UICollectionView, shouldHighlightItemAt indexPath: IndexPath) -> Bool {
 		let (model, adapter) = context(forItemAt: indexPath)
-		return (adapter.dispatchEvent(.didDeselect, model: model, cell: nil, path: indexPath, params: nil) as? Bool) ?? true
+		return (adapter.dispatchEvent(.shouldHighlight, model: model, cell: nil, path: indexPath, params: nil) as? Bool) ?? true
 	}
 
 	func collectionView(_ collectionView: UICollectionView, didHighlightItemAt indexPath: IndexPath) {

--- a/Sources/Owl/Collection/Protocols & Supports/CollectionDirector+Support.swift
+++ b/Sources/Owl/Collection/Protocols & Supports/CollectionDirector+Support.swift
@@ -29,7 +29,7 @@ public extension CollectionDirector {
 
 
 	// MARK: - Public Supporting Structures -
-
+  
 	struct EventsSubscriber {
 		typealias HeaderFooterEvent = (view: UICollectionReusableView, path: IndexPath, table: UICollectionView)
 
@@ -56,6 +56,13 @@ public extension CollectionDirector {
 
 		var endDisplayHeader : ((HeaderFooterEvent) -> Void)? = nil
 		var endDisplayFooter : ((HeaderFooterEvent) -> Void)? = nil
+    
+    private var _contextMenuPreview: ((_ context: AnyObject) -> AnyObject)? = nil
+    @available(iOS 13.0, *)
+    var contextMenuPreview: ((_ context: UIContextMenuConfiguration) -> UITargetedPreview)? {
+      get { _contextMenuPreview as? ((_ context: UIContextMenuConfiguration) -> UITargetedPreview)? ?? nil }
+      set { _contextMenuPreview = newValue as? ((AnyObject) -> AnyObject) }
+    }
 	}
 
 	internal class PrefetchModelsGroup {

--- a/Sources/Owl/Collection/Protocols & Supports/CollectionDirector+Support.swift
+++ b/Sources/Owl/Collection/Protocols & Supports/CollectionDirector+Support.swift
@@ -33,34 +33,28 @@ public extension CollectionDirector {
 	struct EventsSubscriber {
 		typealias HeaderFooterEvent = (view: UICollectionReusableView, path: IndexPath, table: UICollectionView)
 
-		var layoutDidChange: ((_ old: UICollectionViewLayout, _ new: UICollectionViewLayout) -> UICollectionViewTransitionLayout?)? = nil
-		var targetOffset: ((_ proposedContentOffset: CGPoint) -> CGPoint)? = nil
-		var moveItemPath: ((_ originalIndexPath: IndexPath, _ proposedIndexPath: IndexPath) -> IndexPath)? = nil
+		public var layoutDidChange: ((_ old: UICollectionViewLayout, _ new: UICollectionViewLayout) -> UICollectionViewTransitionLayout?)? = nil
+    public var targetOffset: ((_ proposedContentOffset: CGPoint) -> CGPoint)? = nil
+    public var moveItemPath: ((_ originalIndexPath: IndexPath, _ proposedIndexPath: IndexPath) -> IndexPath)? = nil
 
 		private var _shouldUpdateFocus: ((_ context: AnyObject) -> Bool)? = nil
 		@available(iOS 9.0, *)
-		var shouldUpdateFocus: ((_ context: UICollectionViewFocusUpdateContext) -> Bool)? {
+    public var shouldUpdateFocus: ((_ context: UICollectionViewFocusUpdateContext) -> Bool)? {
 			get { return _shouldUpdateFocus }
 			set { _shouldUpdateFocus = newValue as? ((AnyObject) -> Bool) }
 		}
 
 		private var _didUpdateFocus: ((_ context: AnyObject, _ coordinator: AnyObject) -> Void)? = nil
 		@available(iOS 9.0, *)
-		var didUpdateFocus: ((_ context: UICollectionViewFocusUpdateContext, _ coordinator: UIFocusAnimationCoordinator) -> Void)? {
+    public var didUpdateFocus: ((_ context: UICollectionViewFocusUpdateContext, _ coordinator: UIFocusAnimationCoordinator) -> Void)? {
 			get { return _didUpdateFocus }
 			set { _didUpdateFocus = newValue as? ((AnyObject, AnyObject) -> Void) }
 		}
-
-		var willDisplayHeader : ((HeaderFooterEvent) -> Void)? = nil
-		var willDisplayFooter : ((HeaderFooterEvent) -> Void)? = nil
-
-		var endDisplayHeader : ((HeaderFooterEvent) -> Void)? = nil
-		var endDisplayFooter : ((HeaderFooterEvent) -> Void)? = nil
     
     private var _contextMenuPreview: ((_ context: AnyObject) -> AnyObject)? = nil
     @available(iOS 13.0, *)
-    var contextMenuPreview: ((_ context: UIContextMenuConfiguration) -> UITargetedPreview)? {
-      get { _contextMenuPreview as? ((_ context: UIContextMenuConfiguration) -> UITargetedPreview)? ?? nil }
+    public var contextMenuPreview: ((_ context: UIContextMenuConfiguration) -> UITargetedPreview?)? {
+      get { _contextMenuPreview as? ((_ context: UIContextMenuConfiguration) -> UITargetedPreview?)? ?? nil }
       set { _contextMenuPreview = newValue as? ((AnyObject) -> AnyObject) }
     }
 	}

--- a/Sources/Owl/Table/Cell Adapters/TableCellAdapter+Events.swift
+++ b/Sources/Owl/Table/Cell Adapters/TableCellAdapter+Events.swift
@@ -120,6 +120,9 @@ public extension TableCellAdapter {
 
 		@available(iOS 11, *)
 		public lazy var trailingSwipeActions: ((Event) -> UISwipeActionsConfiguration?)? = nil
+    
+    @available(iOS 13, *)
+    public lazy var contextMenuConfiguration: ((Event) -> UIContextMenuConfiguration?)? = nil
 	}
 }
 
@@ -162,4 +165,5 @@ public enum TableAdapterEventID: Int {
 	case canFocus
 	case leadingSwipeActions
 	case trailingSwipeActions
+  case contextMenuConfiguration
 }

--- a/Sources/Owl/Table/Cell Adapters/TableCellAdapter.swift
+++ b/Sources/Owl/Table/Cell Adapters/TableCellAdapter.swift
@@ -197,6 +197,11 @@ open class TableCellAdapter<Model: ElementRepresentable, Cell: ReusableViewProto
 			if #available(iOS 11, *) {
 				return events.trailingSwipeActions?(TableCellAdapter.Event(item: model, cell: cell, indexPath: path))
 			}
+      
+    case .contextMenuConfiguration:
+      if #available(iOS 13, *) {
+        return events.contextMenuConfiguration?(TableCellAdapter.Event(item: model, cell: cell, indexPath: path))
+      }
 
 		}
 

--- a/Sources/Owl/Table/Protocols & Supports/TableDirector+Support.swift
+++ b/Sources/Owl/Table/Protocols & Supports/TableDirector+Support.swift
@@ -40,6 +40,12 @@ public extension TableDirector {
 
 		var didChangeAdjustedContentInset: ((UIScrollView) -> Void)? = nil
 		
+    private var _contextMenuPreview: ((_ context: AnyObject) -> AnyObject)? = nil
+    @available(iOS 13.0, *)
+    var contextMenuPreview: ((_ context: UIContextMenuConfiguration) -> UITargetedPreview)? {
+      get { _contextMenuPreview as? ((_ context: UIContextMenuConfiguration) -> UITargetedPreview)? ?? nil }
+      set { _contextMenuPreview = newValue as? ((AnyObject) -> AnyObject) }
+    }
 	}
 
 	/// Height of the row

--- a/Sources/Owl/Table/Protocols & Supports/TableDirector+Support.swift
+++ b/Sources/Owl/Table/Protocols & Supports/TableDirector+Support.swift
@@ -17,33 +17,11 @@ import UIKit
 public extension TableDirector {
 
 	/// Events you can monitor from the director and related to the table
-	struct TableEventsHandler {
-
-		var didScroll: ((UIScrollView) -> Void)? = nil
-		var endScrollingAnimation: ((UIScrollView) -> Void)? = nil
-
-		var shouldScrollToTop: ((UIScrollView) -> Bool)? = nil
-		var didScrollToTop: ((UIScrollView) -> Void)? = nil
-
-		var willBeginDragging: ((UIScrollView) -> Void)? = nil
-		var willEndDragging: ((_ scrollView: UIScrollView, _ velocity: CGPoint, _ targetOffset: UnsafeMutablePointer<CGPoint>) -> Void)? = nil
-		var endDragging: ((_ scrollView: UIScrollView, _ willDecelerate: Bool) -> Void)? = nil
-
-		var willBeginDecelerating: ((UIScrollView) -> Void)? = nil
-		var endDecelerating: ((UIScrollView) -> Void)? = nil
-
-		// zoom
-		var viewForZooming: ((UIScrollView) -> UIView?)? = nil
-		var willBeginZooming: ((_ scrollView: UIScrollView, _ view: UIView?) -> Void)? = nil
-		var endZooming: ((_ scrollView: UIScrollView, _ view: UIView?, _ scale: CGFloat) -> Void)? = nil
-		var didZoom: ((UIScrollView) -> Void)? = nil
-
-		var didChangeAdjustedContentInset: ((UIScrollView) -> Void)? = nil
-		
+	struct TableEventsHandler {		
     private var _contextMenuPreview: ((_ context: AnyObject) -> AnyObject)? = nil
     @available(iOS 13.0, *)
-    var contextMenuPreview: ((_ context: UIContextMenuConfiguration) -> UITargetedPreview)? {
-      get { _contextMenuPreview as? ((_ context: UIContextMenuConfiguration) -> UITargetedPreview)? ?? nil }
+    public var contextMenuPreview: ((_ context: UIContextMenuConfiguration) -> UITargetedPreview?)? {
+      get { _contextMenuPreview as? ((_ context: UIContextMenuConfiguration) -> UITargetedPreview?)? ?? nil }
       set { _contextMenuPreview = newValue as? ((AnyObject) -> AnyObject) }
     }
 	}

--- a/Sources/Owl/Table/TableDirector.swift
+++ b/Sources/Owl/Table/TableDirector.swift
@@ -35,6 +35,9 @@ open class TableDirector: NSObject, UITableViewDataSourcePrefetching {
 
 	/// Managed `UITableView` instance, not retained.
 	public private(set) weak var table: UITableView?
+  
+  /// Events subscriber
+  public var events = TableDirector.TableEventsHandler()
 
 	/// Events related to the behaviour of the table.
 	public var scrollViewEvents = ScrollViewEventsHandler()
@@ -718,6 +721,11 @@ extension TableDirector: UITableViewDataSource, UITableViewDelegate {
   public func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
     let (model, adapter) = context(forItemAt: indexPath)
     return adapter.dispatchEvent(.contextMenuConfiguration, model: model, cell: nil, path: indexPath, params: nil) as? UIContextMenuConfiguration
+  }
+  
+  @available(iOS 13.0, *)
+  public func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+    return events.contextMenuPreview?(configuration)
   }
 
 	public func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {

--- a/Sources/Owl/Table/TableDirector.swift
+++ b/Sources/Owl/Table/TableDirector.swift
@@ -713,6 +713,12 @@ extension TableDirector: UITableViewDataSource, UITableViewDelegate {
         }
         let _ = adapter.dispatchEvent(.endDisplay, model: nil, cell: cell, path: indexPath, params: nil)
 	}
+  
+  @available(iOS 13.0, *)
+  public func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+    let (model, adapter) = context(forItemAt: indexPath)
+    return adapter.dispatchEvent(.contextMenuConfiguration, model: model, cell: nil, path: indexPath, params: nil) as? UIContextMenuConfiguration
+  }
 
 	public func tableView(_ tableView: UITableView, shouldShowMenuForRowAt indexPath: IndexPath) -> Bool {
 		let (model, adapter) = context(forItemAt: indexPath)

--- a/Sources/Owl/Table/TableSection.swift
+++ b/Sources/Owl/Table/TableSection.swift
@@ -73,16 +73,10 @@ open class TableSection: Equatable, Copying, DifferentiableSection {
 	// MARK: - DifferentiableSection Conformance -
 
 	public func isContentEqual(to other: Differentiable) -> Bool {
-		guard let other = other as? TableSection,
-			elements.count == other.elements.count else {
-				return false
-		}
-		for item in elements.enumerated() {
-			if item.element.isContentEqual(to: other.elements[item.offset]) == false {
-				return false
-			}
-		}
-		return true
+    guard let other = other as? TableSection else {
+      return false
+    }
+    return self.identifier == other.identifier
 	}
 
 	public var differenceIdentifier: String {

--- a/Sources/Owl/Table/TableSection.swift
+++ b/Sources/Owl/Table/TableSection.swift
@@ -72,20 +72,28 @@ open class TableSection: Equatable, Copying, DifferentiableSection {
 
 	// MARK: - DifferentiableSection Conformance -
 
-	public func isContentEqual(to other: Differentiable) -> Bool {
-    guard let other = other as? TableSection else {
-      return false
-    }
-    return self.identifier == other.identifier
-	}
-
-	public var differenceIdentifier: String {
-		return self.identifier
-	}
-
-	public static func == (lhs: TableSection, rhs: TableSection) -> Bool {
-		return lhs.identifier == rhs.identifier
-	}
+  public func isContentEqual(to other: Differentiable) -> Bool {
+      guard let other = other as? TableSection else {
+        return false
+      }
+      return self.identifier == other.identifier
+  }
+  
+  public var differenceIdentifier: String {
+      return self.identifier
+  }
+  
+  public static func == (lhs: TableSection, rhs: TableSection) -> Bool {
+      guard lhs.identifier == rhs.identifier, lhs.elements.count == rhs.elements.count else {
+        return false
+      }
+      for item in lhs.elements.enumerated() {
+        if item.element.isContentEqual(to: rhs.elements[item.offset]) == false {
+          return false
+        }
+      }
+      return true
+  }
 
 	// MARK: - Initialization -
 


### PR DESCRIPTION
## Description 
TableDirector reloads the entire table when it's not necessary.

## How to reproduce
1. Set a section with some elements.
2. Create a new TableSection with the same id as previous and with the same rows.
3. Add some additional new rows to that section.
4. Set that section in reload method:
```swift
    director.reload(afterUpdate: { director -> UITableView.RowAnimation in
      director.set(sections: [section])
      return .automatic
    })
```

EXR: New elements appear on the bottom with animation
ACR: The entire section is reloaded with an animation.

## Fix

A fix for that is to use the same logic to compare sections content as in the `CollectionDirector`.

## Related Issues
#45 

## Also
Additionally, PR includes event fixes in `CollectionDirector` delegate methods.